### PR TITLE
homebrew-bottles: set -e

### DIFF
--- a/homebrew-bottles/sync.sh
+++ b/homebrew-bottles/sync.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 echo "> update package info..."
 export HOME=/root
 export PATH="$HOME/.linuxbrew/bin:$PATH"


### PR DESCRIPTION
to prevent some undefined behavior, like network temporarily failed.