### PR TITLE
lftp: drop `--skip-noaccess` parameter. (fix #31)

### DIFF
--- a/lftpsync/sync.sh
+++ b/lftpsync/sync.sh
@@ -36,6 +36,6 @@ if [[ -n $BIND_ADDRESS ]]; then
 fi
 
 commands+="open $LFTPSYNC_HOST;"
-commands+="mirror --verbose --use-cache --skip-noaccess -aec --parallel=$LFTPSYNC_JOBS $LFTPSYNC_EXCLUDE $LFTPSYNC_PATH $TO"
+commands+="mirror --verbose --use-cache -aec --parallel=$LFTPSYNC_JOBS $LFTPSYNC_EXCLUDE $LFTPSYNC_PATH $TO"
 
 exec lftp -c "$commands"


### PR DESCRIPTION
对于不以/结尾的目录（HTTP协议），如果开启--skip-no-access，lftp会跳过这些目录。

如果确实需要--skip-noaccess参数，可以针对特定源开启该选项，不建议作为公共必选参数。