### PR TITLE
fix(fedora): remove --preallocate

### DIFF
--- a/fedora/pre-sync.sh
+++ b/fedora/pre-sync.sh
@@ -30,7 +30,7 @@ fi
 
 ln -s "$TO" "/mirror/$_MODULE_DIR"
 
-_RSYNCOPTS=(-aSH -f "'R .~tmp~'" --keep-dirlinks --stats --preallocate --delay-updates "--out-format='@ %i  %n%L'")
+_RSYNCOPTS=(-aSH -f "'R .~tmp~'" --keep-dirlinks --stats --delay-updates "--out-format='@ %i  %n%L'")
 
 if [[ -n "${BIND_ADDRESS:+1}" ]]; then
     if [[ "$BIND_ADDRESS" =~ .*: ]]; then


### PR DESCRIPTION
```
rsync: do_fallocate "/mirror/fedora-secondary/updates/26/i386/Packages/m/meshlab-2016.12-6.fc26.i686.rpm": Not supported (95)
```
