### PR TITLE
feat(aptsync): env APTSYNC_CREATE_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ These images are designed for mirroring remote directories/repositories in a con
 | `APTSYNC_URL` | Sets the url of upstream. |
 | `APTSYNC_NTHREADS` | Defaults to `20`. |
 | `APTSYNC_UNLINK` | Set this to `1` to remove unneeded files automatically. Defaults to `0`. |
+| `APTSYNC_CREATE_DIR` | Set this to `true` to create same directory tree as upstream URL. Defaults to `true`. |
 | `APTSYNC_DISTS` | Various distros can be specified in the format `<release> [...]\|<componenet> [...]\|<arch> [...][:...]`. |
 
 Notes: The following `mirror.list`:

--- a/aptsync/Dockerfile
+++ b/aptsync/Dockerfile
@@ -1,6 +1,7 @@
 FROM ustcmirror/base:alpine
 LABEL maintainer="Jian Zeng <anonymousknight96 AT gmail.com>"
 ENV APTSYNC_NTHREADS=20 \
+    APTSYNC_CREATE_DIR=true \
     APTSYNC_UNLINK=0
 RUN apk add --no-cache --update wget perl ca-certificates xz \
         && mkdir -p /var/spool/apt-mirror/mirror /var/spool/apt-mirror/skel /etc/apt/ \


### PR DESCRIPTION
对于部分上游地址（如`http://packages.ros.org/ros/ubuntu`）， 假设 `TO=/srv/repo/ros`，则最终目录结构为 `/srv/repo/ros/ros/ubuntu`。这显然不是我们需要的。

作为workaround，可以配置 `TO=/srv/repo`，但这会损失docker带来的隔离特性。

该PR增加了一个变量`APTSYNC_CREATE_DIR`，用以改变自动创建目录的行为。为了与旧版本相兼容，默认值为 `true`。

link: https://github.com/ustclug/mirrorrequest/issues/195