### PR TITLE
Use `julia-mirror` to mirror Julia ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
     - [gsutil-rsync](#gsutil-rsync)
     - [hackage](#hackage)
     - [homebrew-bottles](#homebrew-bottles)
+    - [julia](#julia)
     - [lftpsync](#lftpsync)
     - [nodesource](#nodesource)
     - [pypi](#pypi)
@@ -171,6 +172,10 @@ See [dist conf](https://pagure.io/quick-fedora-mirror/blob/master/f/quick-fedora
 | Parameter                | Description                              |
 | ------------------------ | ---------------------------------------- |
 | `HOMEBREW_BOTTLE_DOMAIN` | Set the URL of upstream. Defaults to `http://homebrew.bintray.com` |
+
+### julia
+
+Sync from official site.  No parameters needed.
 
 ### lftpsync
 

--- a/julia/Dockerfile
+++ b/julia/Dockerfile
@@ -1,0 +1,6 @@
+FROM ustcmirror/base:alpine
+MAINTAINER Elliot Saba <staticfloat@gmail.com>
+RUN apk add --no-cache python3 git bash && \
+    git clone https://github.com/sunoru/julia-mirror /julia-mirror
+RUN pip3 install gitpython toml
+ADD sync.sh /

--- a/julia/Dockerfile
+++ b/julia/Dockerfile
@@ -1,6 +1,6 @@
 FROM ustcmirror/base:alpine
 MAINTAINER Elliot Saba <staticfloat@gmail.com>
-RUN apk add --no-cache python3 git bash && \
+RUN apk add --no-cache python3 git && \
     git clone https://github.com/sunoru/julia-mirror /julia-mirror
 RUN pip3 install gitpython toml
 ADD sync.sh /

--- a/julia/Dockerfile
+++ b/julia/Dockerfile
@@ -1,6 +1,6 @@
 FROM ustcmirror/base:alpine
 MAINTAINER Elliot Saba <staticfloat@gmail.com>
 RUN apk add --no-cache python3 git && \
-    git clone https://github.com/sunoru/julia-mirror /julia-mirror
-RUN pip3 install gitpython toml
+    git clone https://github.com/sunoru/julia-mirror /julia-mirror && \
+    pip3 install gitpython toml
 ADD sync.sh /

--- a/julia/sync.sh
+++ b/julia/sync.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 mkdir -p /data/tmp
 python3 /julia-mirror/scripts/mirror_julia.py /data --logging-file /logs/mirror_julia.log --temp-dir=/data/tmp

--- a/julia/sync.sh
+++ b/julia/sync.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p /data/tmp
+python3 /julia-mirror/scripts/mirror_julia.py /data --logging-file /logs/mirror_julia.log --temp-dir=/data/tmp
+rm -rf /data/tmp

--- a/julia/sync.sh
+++ b/julia/sync.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-mkdir -p $TO/tmp
-python3 /julia-mirror/scripts/mirror_julia.py /data --logging-file /logs/mirror_julia.log --temp-dir=/data/tmp
-rm -rf /data/tmp
+mkdir -p ${TO}/tmp
+python3 /julia-mirror/scripts/mirror_julia.py ${TO} --logging-file ${LOGDIR}/mirror_julia.log --temp-dir=${TO}/tmp
+rm -rf ${TO}/tmp

--- a/julia/sync.sh
+++ b/julia/sync.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-mkdir -p /data/tmp
+mkdir -p $TO/tmp
 python3 /julia-mirror/scripts/mirror_julia.py /data --logging-file /logs/mirror_julia.log --temp-dir=/data/tmp
 rm -rf /data/tmp

--- a/julia/sync.sh
+++ b/julia/sync.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 mkdir -p ${TO}/tmp
-python3 /julia-mirror/scripts/mirror_julia.py ${TO} --logging-file ${LOGDIR}/mirror_julia.log --temp-dir=${TO}/tmp
+python3 /julia-mirror/scripts/mirror_julia.py ${TO} --temp-dir=${TO}/tmp
 rm -rf ${TO}/tmp


### PR DESCRIPTION
### Checklist

- [X] 更新 README

This uses the [`julia-mirror` scripts](https://github.com/sunoru/julia-mirror) to download the Julia ecosystem (Julia versions, Julia packages, etc...) to `/data` within the docker container, outputting logs into `/logs`.
