### PR TITLE
fix: pass --fail to curl in case of server errors

### DIFF
--- a/base/Dockerfile.centos
+++ b/base/Dockerfile.centos
@@ -5,4 +5,4 @@ ADD ["entry.sh", "savelog", "/usr/local/bin/"]
 VOLUME ["/data", "/log"]
 ENTRYPOINT ["entry.sh"]
 RUN ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
-    curl -o /usr/local/bin/su-exec http://ftp.ustclug.org/misc/su-exec && chmod +x /usr/local/bin/su-exec
+    curl --fail -o /usr/local/bin/su-exec https://ftp.lug.ustc.edu.cn/misc/su-exec && chmod +x /usr/local/bin/su-exec

--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -1,6 +1,6 @@
 FROM ustcmirror/base:alpine
 LABEL maintainer "Shengjing Zhu <zsj950618@gmail.com>"
 RUN apk add --no-cache zsh curl rsync ca-certificates gawk grep bzip2 coreutils diffutils findutils \
-    && curl -o /usr/local/bin/quick-fedora-mirror https://pagure.io/quick-fedora-mirror/raw/master/f/quick-fedora-mirror \
+    && curl --fail -o /usr/local/bin/quick-fedora-mirror https://pagure.io/quick-fedora-mirror/raw/master/f/quick-fedora-mirror \
     && chmod +x /usr/local/bin/quick-fedora-mirror
 ADD ["pre-sync.sh", "sync.sh", "/"]

--- a/freebsd-pkg/sync.sh
+++ b/freebsd-pkg/sync.sh
@@ -89,7 +89,7 @@ channel_sync() {
 	download_or_fail false Latest/{pkg-devel.txz,pkg.txz,pkg.txz.sig}
 
 	# get packages
-	tar -C $tmpdir -xJf $tmpdir/packagesite.txz packagesite.yaml 
+	tar -C $tmpdir -xJf $tmpdir/packagesite.txz packagesite.yaml
 	if [[ $? -ne 0 ]]; then
 		echo '[FATAL] unzip packagesite.txz failed.'
 		return 1
@@ -121,12 +121,12 @@ is_ipv6() {
 
 if [[ -n $BIND_ADDRESS ]]; then
 	if is_ipv6 "$BIND_ADDRESS"; then
-		CURL_WRAP="curl -6 --interface $BIND_ADDRESS"
+		CURL_WRAP="curl --fail -6 --interface $BIND_ADDRESS"
 	else
-		CURL_WRAP="curl -4 --interface $BIND_ADDRESS"
+		CURL_WRAP="curl --fail -4 --interface $BIND_ADDRESS"
 	fi
 else
-	CURL_WRAP="curl"
+	CURL_WRAP="curl --fail"
 fi
 export CURL_WRAP
 

--- a/freebsd-ports/sync-ports.sh
+++ b/freebsd-ports/sync-ports.sh
@@ -12,7 +12,7 @@ removal_list=$(mktemp)
 download_and_check() {
 	while read sum repopath; do
 		[[ -f $local_dir/$repopath ]] && continue
-		curl -m 600 -sSfRL --create-dirs -o $local_dir/$repopath.tmp $remote_url/$repopath
+		curl --fail -m 600 -sSfRL --create-dirs -o $local_dir/$repopath.tmp $remote_url/$repopath
 		if [[ $? -ne 0 ]]; then
 			echo "[WARN] download failed $remote_url/$repopath"
 			rm -f $local_dir/$repopath.tmp
@@ -54,13 +54,13 @@ remote_url=$FBSD_PORTS_DISTFILES_UPSTREAM local_dir=$TO/distfiles parallel -j $F
 git -C $TO/ports.git archive --format=tar.gz -o $TO/ports.tar.gz HEAD
 
 # remove old distfile
-comm -23 <(cd $TO/distfiles; find . -type f | sed 's/^\.\///g' | sort) <(awk '{print $2}' $meta) | tee $removal_list | xargs rm -f 
-sed 's/^/[INFO] remove /g' $removal_list 
+comm -23 <(cd $TO/distfiles; find . -type f | sed 's/^\.\///g' | sort) <(awk '{print $2}' $meta) | tee $removal_list | xargs rm -f
+sed 's/^/[INFO] remove /g' $removal_list
 
 # fix dir mode
 find $TO -type d -print0 | xargs -0 chmod 755
 
 # cleam temp file
-rm -f $meta $removal_list 
+rm -f $meta $removal_list
 rm -r $tmpdir
 


### PR DESCRIPTION
在用到 curl 的地方都加上了 `--fail`，防止下载下来的是一个 html 文件