### PR TITLE
Skopeo (Docker container) sync

### DIFF
--- a/skopeo-sync/Dockerfile
+++ b/skopeo-sync/Dockerfile
@@ -1,0 +1,4 @@
+FROM ustcmirror/base:alpine
+LABEL maintainer "Keyu Tao <taoky AT ustclug.org>"
+RUN apk add --no-cache skopeo
+ADD sync.sh /

--- a/skopeo-sync/Dockerfile
+++ b/skopeo-sync/Dockerfile
@@ -1,4 +1,5 @@
-FROM ustcmirror/base:alpine
+FROM ustcmirror/base:alpine-edge
 LABEL maintainer "Keyu Tao <taoky AT ustclug.org>"
 RUN apk add --no-cache skopeo
 ADD sync.sh /
+ADD skopeo-images.yaml /etc/

--- a/skopeo-sync/skopeo-images.yaml
+++ b/skopeo-sync/skopeo-images.yaml
@@ -1,0 +1,10 @@
+k8s.gcr.io:
+  images:
+    kube-apiserver:
+      - v1.18.3
+      - v1.18.4
+      - v1.18.5
+registry.hub.docker.com:
+  images:
+    library/hello-world:
+      - latest

--- a/skopeo-sync/skopeo-images.yaml
+++ b/skopeo-sync/skopeo-images.yaml
@@ -1,9 +1,29 @@
 k8s.gcr.io:
   images:
+    pause:
+      - 3.1
+      - 3.2
     kube-apiserver:
       - v1.18.3
       - v1.18.4
       - v1.18.5
+    kube-controller-manager:
+      - v1.18.3
+      - v1.18.4
+      - v1.18.5
+    kube-scheduler:
+      - v1.18.3
+      - v1.18.4
+      - v1.18.5
+    kube-proxy:
+      - v1.18.3
+      - v1.18.4
+      - v1.18.5
+    etcd:
+      - 3.4.3-0
+      - 3.4.7-0
+    coredns:
+      - 1.6.7
 registry.hub.docker.com:
   images:
     library/hello-world:

--- a/skopeo-sync/sync.sh
+++ b/skopeo-sync/sync.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
 
-skopeo login -u mirror -p "$REGISTRY_PASSWD" "$REGISTRY_HOST"
-exec skopeo --insecure-policy sync --scoped --src yaml --dest docker /etc/skopeo-images.yaml "$REGISTRY_HOST"
+VERIFY_TLS=${VERIFY_TLS:-"false"}
+
+if [ -n "$NEEDS_LOGIN" ]; then
+  skopeo login --tls-verify="$VERIFY_TLS" "$REGISTRY_HOST" -u "$REGISTRY_USERNAME" -p "$REGISTRY_PASSWORD"
+  if [ $? -ne 0 ]; then
+    echo "Registry login failed"
+    exit 255
+  fi
+fi
+
+exec skopeo --insecure-policy sync --dest-tls-verify="$VERIFY" --scoped --src yaml --dest docker /etc/skopeo-images.yaml "$REGISTRY_HOST"

--- a/skopeo-sync/sync.sh
+++ b/skopeo-sync/sync.sh
@@ -1,32 +1,4 @@
 #!/usr/bin/env bash
 
-cat > /etc/skopeo-images.yaml <<EOF
-k8s.gcr.io:
-  images:
-    pause:
-      - 3.1
-      - 3.2
-    kube-apiserver:
-      - v1.18.3
-      - v1.18.4
-      - v1.18.5
-    kube-controller-manager:
-      - v1.18.3
-      - v1.18.4
-      - v1.18.5
-    kube-scheduler:
-      - v1.18.3
-      - v1.18.4
-      - v1.18.5
-    kube-proxy:
-      - v1.18.3
-      - v1.18.4
-      - v1.18.5
-    etcd:
-      - 3.4.3-0
-      - 3.4.7-0
-    coredns:
-      - 1.6.7
-EOF
-
-exec skopeo --insecure-policy sync --src yaml --dest docker /etc/skopeo-images.yaml "$TO"
+skopeo login -u mirror -p "$REGISTRY_PASSWD" "$REGISTRY_HOST"
+exec skopeo --insecure-policy sync --scoped --src yaml --dest docker /etc/skopeo-images.yaml "$REGISTRY_HOST"

--- a/skopeo-sync/sync.sh
+++ b/skopeo-sync/sync.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+cat > /etc/skopeo-images.yaml <<EOF
+k8s.gcr.io:
+  images:
+    pause:
+      - 3.1
+      - 3.2
+    kube-apiserver:
+      - v1.18.3
+      - v1.18.4
+      - v1.18.5
+    kube-controller-manager:
+      - v1.18.3
+      - v1.18.4
+      - v1.18.5
+    kube-scheduler:
+      - v1.18.3
+      - v1.18.4
+      - v1.18.5
+    kube-proxy:
+      - v1.18.3
+      - v1.18.4
+      - v1.18.5
+    etcd:
+      - 3.4.3-0
+      - 3.4.7-0
+    coredns:
+      - 1.6.7
+EOF
+
+exec skopeo --insecure-policy sync --src yaml --dest docker /etc/skopeo-images.yaml "$TO"


### PR DESCRIPTION
### Checklist

- [ ] 更新 README

(如果方便的话, 可以简述一下您所做的改动)

https://github.com/ustclug/mirrorrequest/issues/276

尝试使用 skopeo 进行 Docker 镜像同步。

详情：
- mirrors 本地开一个 registry，通过 nginx 反代 GET/HEAD only 限制外部 push。（如果需要设置密码，registry 就必须配置 TLS，这样的话反代什么的会非常麻烦）
- yuki 定时启动 skopeo（本 PR 的 `skopeo-sync`），同步指定的镜像。
- 镜像列表很长，不适合写在环境变量里。我的想法是就写在配置里面，如果需要增减镜像的话，`skopeo-sync/` 下的配置 YAML 也需要更新。
