### PR TITLE
让 configure.py 可以正确处理使用了 multi-stage build 的 Dockerfile

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -O
+#!/usr/bin/env python -O
 # -*- coding: utf-8 -*-
 import os
 from os import path
@@ -54,7 +54,6 @@ class NaryTree():
     """
     A n-ary tree
     """
-
     def __init__(self, name):
         self.name = name
         self._children = dict()
@@ -146,23 +145,19 @@ class Builder():
         if is_cron:
             to_build = self._dep_tree.enum_all()
         else:
-            # TRAVIS_COMMIT_RANGE is empty for builds
-            # triggered by the initial commit of a new branch.
-            commits_range = os.environ.get('TRAVIS_COMMIT_RANGE', '')
-            print('TRAVIS_COMMIT_RANGE: {}'.format(commits_range))
-            if not commits_range:
-                # GitHub Actions ($COMMIT_FROM & $COMMIT_TO)
-                commit_from = os.environ.get('COMMIT_FROM', '')
-                commit_to = os.environ.get('COMMIT_TO', '')
-                if commit_from and commit_to:
-                    commits_range = "{}...{}".format(commit_from, commit_to)
-                else:
-                    # git clone --branch <branch> on travis
-                    # need to add master branch back
-                    if not Git.branch_exists('master'):
-                        print('fetching master branch...')
-                        Git.fetch_master_branch()
-                    commits_range = 'origin/master...HEAD'
+            # GitHub Actions ($COMMIT_FROM & $COMMIT_TO)
+            commit_from = os.environ.get('COMMIT_FROM', '')
+            commit_to = os.environ.get('COMMIT_TO', '')
+            if commit_from and commit_to:
+                commits_range = "{}...{}".format(commit_from, commit_to)
+            else:
+                # git clone --branch <branch> on travis
+                # need to add master branch back
+                if not Git.branch_exists('master'):
+                    print('fetching master branch...')
+                    Git.fetch_master_branch()
+                commits_range = 'origin/master...HEAD'
+            print('COMMITS_RANGE: {}'.format(commits_range))
             prev, current = commits_range.split('...')
             if Git.is_invalid_commit(prev):
                 if Git.is_current_branch('master'):
@@ -237,7 +232,8 @@ def get_dest_image(img, f):
 
 def get_base_image(f):
     with open(f) as fin:
-        for l in fin:
+        # Read Dockerfile in reverse order to get the base image
+        for l in reversed(fin.readlines()):
             l = l.strip()
             if not l.startswith('FROM'):
                 continue

--- a/homebrew-bottles/Dockerfile
+++ b/homebrew-bottles/Dockerfile
@@ -1,4 +1,4 @@
-from rustlang/rust:nightly-alpine as builder
+FROM rustlang/rust:nightly-alpine AS builder
 WORKDIR /usr/src/bottles-json/
 COPY bottles-json .
 RUN apk add --no-cache musl-dev
@@ -6,6 +6,6 @@ RUN cargo build --release
 
 FROM ustcmirror/curl-helper
 LABEL maintainer="Yifan Gao docker@yfgao.com"
-RUN apk add --no-cache parallel bash sed 
+RUN apk add --no-cache parallel bash sed
 ADD sync.sh /
 COPY --from=builder /usr/src/bottles-json/target/release/bottles-json /usr/local/bin/

--- a/rsync/Dockerfile
+++ b/rsync/Dockerfile
@@ -1,4 +1,4 @@
-from ustcmirror/base:alpine as builder
+FROM ustcmirror/base:alpine AS builder
 RUN apk add --no-cache build-base
 WORKDIR /tmp
 ADD lchmod.c .


### PR DESCRIPTION
* 现在 `configure.py` 在读 Dockerfile 的时候会从后往前读，把读到的第一个 `FROM` 指令后的 image 作为 base image
* 顺便去掉了 `configure.py` 里读取环境变量 `TRAVIS_COMMIT_RANGE` 的逻辑
