### PR TITLE
Replace shell script with Python

### DIFF
--- a/apt-sync/Dockerfile
+++ b/apt-sync/Dockerfile
@@ -3,4 +3,4 @@ MAINTAINER iBug <docker@ibugone.com>
 RUN apk add --no-cache --update wget perl ca-certificates git python3 py3-requests && \
     mkdir -p /usr/local/lib/tunasync
 ADD tunasync /usr/local/lib/tunasync
-ADD sync.sh /
+ADD sync.sh sync.py /

--- a/apt-sync/sync.py
+++ b/apt-sync/sync.py
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import re
 import subprocess
 
 
@@ -18,7 +19,9 @@ os.chdir(WORK_DIR)
 
 cmds = []
 rets = []
-for dist in APTSYNC_DISTS.split(":"):
+for dist in re.split(r"[:\n]+", APTSYNC_DISTS):
+    if not dist.strip():
+        continue
     apt_dist, apt_comp, apt_arch, apt_dir = dist.strip().split("|")
     apt_arch = apt_arch.replace(" ", ",")
     apt_comp = apt_comp.replace(" ", ",")

--- a/apt-sync/sync.py
+++ b/apt-sync/sync.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python3
+
+import sys
+import os
+import subprocess
+
+
+DEBUG = os.environ.get("DEBUG")
+WORK_DIR = "/usr/local/lib/tunasync"
+
+APTSYNC_URL = os.environ["APTSYNC_URL"]
+APTSYNC_DISTS = os.environ["APTSYNC_DISTS"]
+TO = os.environ["TO"]
+DELETE = os.environ.get("APTSYNC_UNLINK", "")
+
+
+os.chdir(WORK_DIR)
+
+cmds = []
+rets = []
+for dist in APTSYNC_DISTS.split(":"):
+    apt_dist, apt_comp, apt_arch, apt_dir = dist.strip().split("|")
+    apt_arch = apt_arch.replace(" ", ",")
+    apt_comp = apt_comp.replace(" ", ",")
+
+    cmd = [sys.executable, "apt-sync.py"]
+    if DELETE:
+        cmd.append("--delete")
+
+    cmd += [APTSYNC_URL + apt_dir, apt_dist, apt_comp, apt_arch, TO + "/" + apt_dir]
+    cmds.append(cmd[:])
+    cp = subprocess.run(cmd)
+    rets.append(cp.returncode)
+
+if DEBUG:
+    for cmd, ret in zip(cmds, rets):
+        print(f"CMD {cmd} = {ret}", file=sys.stderr)
+
+sys.exit(sum(rets))

--- a/apt-sync/sync.py
+++ b/apt-sync/sync.py
@@ -27,7 +27,7 @@ for dist in APTSYNC_DISTS.split(":"):
     if DELETE:
         cmd.append("--delete")
 
-    cmd += [APTSYNC_URL + apt_dir, apt_dist, apt_comp, apt_arch, TO + "/" + apt_dir]
+    cmd += [APTSYNC_URL + apt_dir, apt_dist, apt_comp, apt_arch, os.path.join(TO, apt_dir)]
     cmds.append(cmd[:])
     cp = subprocess.run(cmd)
     rets.append(cp.returncode)

--- a/apt-sync/sync.sh
+++ b/apt-sync/sync.sh
@@ -1,36 +1,4 @@
 #!/bin/bash
 
-set -e
-[[ $DEBUG = true ]] && set -x
-
-if [[ -n "$APTSYNC_UNLINK" ]]; then
-  DELETE=--delete
-fi
-
 cd /usr/local/lib/tunasync
-DISTS="$APTSYNC_DISTS:"
-RET=0
-while [[ "$DISTS" == *:* ]]; do
-  THISDIST="${DISTS%%:*}"
-  THISDIST="${THISDIST%"${THISDIST##*[![:space:]]}"}"
-  THISDIST="${THISDIST#"${THISDIST%%[![:space:]]*}"}"
-  THISDIST="${THISDIST}|"
-  DISTS="${DISTS#*:}"
-
-  APT_DIST="${THISDIST}"
-  APT_COMP="${APT_DIST#*|}"
-  APT_ARCH="${APT_COMP#*|}"
-  APT_DIR="${APT_ARCH#*|}"
-
-  APT_DIST="${THISDIST%%|*}"
-  APT_COMP="${APT_COMP%%|*}"
-  APT_ARCH="${APT_ARCH%%|*}"
-  APT_DIR="${APT_DIR%%|*}"
-
-  APT_ARCH="${APT_ARCH// /,}"
-  APT_COMP="${APT_COMP// /,}"
-
-  python3 apt-sync.py $DELETE "$APTSYNC_URL""${APT_DIR}" "$APT_DIST" "$APT_COMP" "$APT_ARCH" "${TO}/${APT_DIR}" || RET=$((RET+$?))
-done
-
-exit $RET
+exec python3 /sync.py


### PR DESCRIPTION
Motivation:

Originally attempted to trim whitespaces around each `APTSYNC_DIST` item to allow saner configuration. For example, our conf for Termux is currently:

```yaml
envs:
  APTSYNC_DISTS: stable|main|aarch64 all arm i686 x86_64|k51qzi5uqu5dg9vawh923wejqffxiu9bhqlze5f508msk0h7ylpac27fdgaskx:unstable|main|aarch64 all arm i686 x86_64|k51qzi5uqu5dj05z8mr958kwvrg7a0wqouj5nnoo5uqu1btnsljvpznfaav9nk:x11|main|aarch64 arm i686 x86_64|k51qzi5uqu5dgu3homski160l4t4bmp52vb6dbgxb5bda90rewnwg64wnkwxj4:science|stable|aarch64 all arm i686 x86_64|k51qzi5uqu5dhvbtvdf46kkhobzgamhiirte6s6k28l2c1iapumphh3cpkw33f:games|stable|aarch64 arm i686 x86_64|k51qzi5uqu5dhngjg68o8x9uimwy5h8iqt91n2266idc7uet9ew3lc472upy27:root|stable|aarch64 arm i686 x86_64|k51qzi5uqu5dlp5yjlahzcp3kfpnhbifo9ka9iybo3bp5vt781duafkyyvt9al
```

With whitespace trimmed around each dist, it could be rewritten as:

```yaml
envs:
  APTSYNC_DISTS: >
    stable|main|aarch64 all arm i686 x86_64|k51qzi5uqu5dg9vawh923wejqffxiu9bhqlze5f508msk0h7ylpac27fdgaskx
    :unstable|main|aarch64 all arm i686 x86_64|k51qzi5uqu5dj05z8mr958kwvrg7a0wqouj5nnoo5uqu1btnsljvpznfaav9nk
    :x11|main|aarch64 arm i686 x86_64|k51qzi5uqu5dgu3homski160l4t4bmp52vb6dbgxb5bda90rewnwg64wnkwxj4
    :science|stable|aarch64 all arm i686 x86_64|k51qzi5uqu5dhvbtvdf46kkhobzgamhiirte6s6k28l2c1iapumphh3cpkw33f
    :games|stable|aarch64 arm i686 x86_64|k51qzi5uqu5dhngjg68o8x9uimwy5h8iqt91n2266idc7uet9ew3lc472upy27
    :root|stable|aarch64 arm i686 x86_64|k51qzi5uqu5dlp5yjlahzcp3kfpnhbifo9ka9iybo3bp5vt781duafkyyvt9al
```

which is arguably easier to read and maintain.

However, that kind of seemingly simple string operation may or may not actually be easy to perform with shell scripts (e.g. e4f1ed9743314b033930134a18758df8915221f6, and see how we do string splitting), so replacing with Python should be a wise move in the long run.