### PR TITLE
Migrate crates.io-index sync script to docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,12 @@ A.K.A. [ftpsync](https://anonscm.debian.org/cgit/mirror/archvsync.git/)
 
 A dedicated script to sync <https://github.com/rust-lang/crates.io-index>.
 
-| Parameter       | Description                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------- |
-| `CRATES_PROXY`  | The URL that crates will be redirected to. Defaults to `https://crates-io.proxy.ustclug.org/api/v1/crates` |
-| `CRATES_GITMSG` | The commit message of `config.json`. Defaults to `Redirect to USTC Mirrors`                                |
+| Parameter        | Description                                                                                                |
+| ---------------- | ---------------------------------------------------------------------------------------------------------- |
+| `CRATES_PROXY`   | The URL that crates will be redirected to. Defaults to `https://crates-io.proxy.ustclug.org/api/v1/crates` |
+| `CRATES_GITMSG`  | The commit message of `config.json`. Defaults to `Redirect to USTC Mirrors`                                |
+| `CRATES_GITMAIL` | `user.email` when committing `config.json`. Defaults to `lug AT ustc.edu.cn`                               |
+| `CRATES_GITNAME` | `user.name` when committing `config.json`. Defaults to `mirror`                                            |
 
 ### debian-cd
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     - [aptsync](#aptsync)
     - [apt-sync](#apt-sync)
     - [archvsync](#archvsync)
+    - [crates-io-index](#crates-io-index)
     - [debian-cd](#debian-cd)
     - [docker-ce](#docker-ce)
     - [fedora](#fedora)
@@ -129,6 +130,18 @@ A.K.A. [ftpsync](https://anonscm.debian.org/cgit/mirror/archvsync.git/)
 | Parameter     | Description                                    |
 | ------------- | ---------------------------------------------- |
 | `IGNORE_LOCK` | Purge lockfiles at first. Defaults to `false`. |
+
+### crates-io-index
+
+[![crates-io-index](https://img.shields.io/docker/image-size/ustcmirror/crates-io-index/latest)](https://hub.docker.com/r/ustcmirror/crates-io-index "crates-io-index")
+[![crates-io-index](https://img.shields.io/docker/pulls/ustcmirror/crates-io-index)](https://hub.docker.com/r/ustcmirror/crates-io-index "crates-io-index")
+
+A dedicated script to sync <https://github.com/rust-lang/crates.io-index>.
+
+| Parameter       | Description                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------- |
+| `CRATES_PROXY`  | The URL that crates will be redirected to. Defaults to `https://crates-io.proxy.ustclug.org/api/v1/crates` |
+| `CRATES_GITMSG` | The commit message of `config.json`. Defaults to `Redirect to USTC Mirrors`                                |
 
 ### debian-cd
 

--- a/crates-io-index/Dockerfile
+++ b/crates-io-index/Dockerfile
@@ -1,0 +1,4 @@
+FROM ustcmirror/base:alpine
+LABEL maintainer "Keyu Tao <taoky AT lug.ustc.edu.cn>"
+RUN apk add --no-cache git
+ADD sync.sh /

--- a/crates-io-index/sync.sh
+++ b/crates-io-index/sync.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Migrated to yuki (docker) by @taoky
+# Created by @ksqsf
+# Based on the original version written by @knight42
+
+# ENVS:
+# CRATES_PROXY=
+# CRATES_GITMSG=
+
+set -e
+[[ -n $DEBUG ]] && set -x
+
+CRATES_PROXY="${CRATES_PROXY:-https://crates-io.proxy.ustclug.org/api/v1/crates}"
+CRATES_GITMSG="${CRATES_GITMSG:-Redirect to USTC Mirrors}"
+
+ensure_redirect() {
+    pushd "$TO"
+    if grep -F -q "$CRATES_PROXY" 'config.json'; then
+        return
+    else
+        cat <<EOF > 'config.json'
+{
+    "dl": "$CRATES_PROXY",
+    "api": "https://crates.io/"
+}
+EOF
+        git add config.json
+        git commit -qm "$CRATES_GITMSG"
+    fi
+    popd
+}
+
+# crates.io-index has a custom ensure_redirect logic
+# so now we don't use gitsync here.
+
+if [[ -d $TO ]]; then
+    cd "$TO"
+    git fetch origin
+    git reset --hard origin/master
+    ensure_redirect
+    git repack -adb
+    git gc --auto
+    git update-server-info
+else
+    git clone 'https://github.com/rust-lang/crates.io-index.git' "$TO"
+    ensure_redirect
+fi

--- a/crates-io-index/sync.sh
+++ b/crates-io-index/sync.sh
@@ -32,7 +32,7 @@ ensure_redirect() {
 }
 EOF
         git add config.json
-        git -c user.name "$CRATES_GITNAME" -c user.email "$CRATES_GITMAIL" commit -qm "$CRATES_GITMSG"
+        git -c user.name="$CRATES_GITNAME" -c user.email="$CRATES_GITMAIL" commit -qm "$CRATES_GITMSG"
     fi
     popd
 }

--- a/crates-io-index/sync.sh
+++ b/crates-io-index/sync.sh
@@ -17,6 +17,8 @@ set -e
 
 CRATES_PROXY="${CRATES_PROXY:-https://crates-io.proxy.ustclug.org/api/v1/crates}"
 CRATES_GITMSG="${CRATES_GITMSG:-Redirect to USTC Mirrors}"
+CRATES_GITMAIL="${CRATES_GITMAIL:-lug AT ustc.edu.cn}"
+CRATES_GITNAME="${CRATES_GITNAME:mirror}"
 
 ensure_redirect() {
     pushd "$TO"
@@ -30,7 +32,7 @@ ensure_redirect() {
 }
 EOF
         git add config.json
-        git commit -qm "$CRATES_GITMSG"
+        git -c user.name "$CRATES_GITNAME" -c user.email "$CRATES_GITMAIL" commit -qm "$CRATES_GITMSG"
     fi
     popd
 }

--- a/crates-io-index/sync.sh
+++ b/crates-io-index/sync.sh
@@ -8,6 +8,10 @@
 # CRATES_PROXY=
 # CRATES_GITMSG=
 
+is_empty() {
+    [[ -z $(ls -A "$1" 2>/dev/null) ]]
+}
+
 set -e
 [[ -n $DEBUG ]] && set -x
 
@@ -34,7 +38,7 @@ EOF
 # crates.io-index has a custom ensure_redirect logic
 # so now we don't use gitsync here.
 
-if [[ -d $TO ]]; then
+if ! is_empty "$TO"; then
     cd "$TO"
     git fetch origin
     git reset --hard origin/master

--- a/crates-io-index/sync.sh
+++ b/crates-io-index/sync.sh
@@ -18,7 +18,7 @@ set -e
 CRATES_PROXY="${CRATES_PROXY:-https://crates-io.proxy.ustclug.org/api/v1/crates}"
 CRATES_GITMSG="${CRATES_GITMSG:-Redirect to USTC Mirrors}"
 CRATES_GITMAIL="${CRATES_GITMAIL:-lug AT ustc.edu.cn}"
-CRATES_GITNAME="${CRATES_GITNAME:mirror}"
+CRATES_GITNAME="${CRATES_GITNAME:-mirror}"
 
 ensure_redirect() {
     pushd "$TO"

--- a/crates-io-index/sync.sh
+++ b/crates-io-index/sync.sh
@@ -7,6 +7,8 @@
 # ENVS:
 # CRATES_PROXY=
 # CRATES_GITMSG=
+# CRATES_GITMAIL=
+# CRATES_GITNAME=
 
 is_empty() {
     [[ -z $(ls -A "$1" 2>/dev/null) ]]


### PR DESCRIPTION
### Checklist

- [x] 更新 README

将目前使用 crontab 的 crates.io-index 同步任务迁移至能够用 Yuki 管理的 Docker。
