### PR TITLE
Migrate AOSP sync script to docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
     - [ghcup](#ghcup)
     - [github-release](#github-release)
     - [gitsync](#gitsync)
+    - [google-repo](#google-repo)
     - [gsutil-rsync](#gsutil-rsync)
     - [hackage](#hackage)
     - [homebrew-bottles](#homebrew-bottles)
@@ -248,6 +249,17 @@ To specified the repo list to sync, you can:
 | `GITSYNC_BRANCH` | Defaults to `master:master`.              |
 | `GITSYNC_REMOTE` | Defaults to `origin`.                     |
 | `GITSYNC_BITMAP` | Enable bitmap index. Defaults to `false`. |
+
+### google-repo
+
+[![google-repo](https://img.shields.io/docker/image-size/ustcmirror/google-repo/latest)](https://hub.docker.com/r/ustcmirror/google-repo "google-repo")
+[![google-repo](https://img.shields.io/docker/pulls/ustcmirror/google-repo)](https://hub.docker.com/r/ustcmirror/google-repo "google-repo")
+
+A script for syncing projects (especially AOSP) using Google's `repo` tool.
+
+| Parameter  | Description                                                                  |
+| ---------- | ---------------------------------------------------------------------------- |
+| `UPSTREAM` | Upstream URL. Defaults to `https://android.googlesource.com/mirror/manifest` |
 
 ### gsutil-rsync
 

--- a/google-repo/Dockerfile
+++ b/google-repo/Dockerfile
@@ -1,0 +1,6 @@
+FROM ustcmirror/base:alpine
+LABEL maintainer "Keyu Tao <taoky AT lug.ustc.edu.cn>"
+RUN apk add --no-cache git curl && \
+    curl -fLo /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
+    chmod +x /usr/local/bin/repo
+ADD sync.sh /

--- a/google-repo/Dockerfile
+++ b/google-repo/Dockerfile
@@ -1,6 +1,7 @@
 FROM ustcmirror/base:alpine
 LABEL maintainer "Keyu Tao <taoky AT lug.ustc.edu.cn>"
-RUN apk add --no-cache git curl && \
+RUN apk add --no-cache git curl python3 openssh-client && \
     curl -fLo /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
+    sed -i 's|^#!/usr/bin/env python|#!/usr/bin/python3|' /usr/local/bin/repo && \
     chmod +x /usr/local/bin/repo
 ADD sync.sh /

--- a/google-repo/sync.sh
+++ b/google-repo/sync.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+[[ -n $DEBUG ]] && set -x
+
+UPSTREAM="${UPSTREAM:-https://android.googlesource.com/mirror/manifest}"
+
+PATH=/usr/local/bin:$PATH
+
+cd "$TO"
+
+# Check if repo has been initialized
+echo "initalizing repo"
+if [[ ! -d "$TO"/.repo ]]; then
+    repo init -u "$UPSTREAM" --mirror
+fi
+
+# Now start syncing
+echo "start repo sync"
+repo_ret=0
+# Don't let syncing failure stop repacking
+repo --trace sync || repo_ret=$?
+if [[ ! $repo_ret == 0 ]]; then
+    echo "[warn]: repo sync returns an unzero exit code: $repo_ret"
+fi
+echo "start repacking git objects"
+find -name "*.git" -exec bash -c "pushd {} && git repack -abd" \;
+
+exit $repo_ret

--- a/google-repo/sync.sh
+++ b/google-repo/sync.sh
@@ -10,8 +10,8 @@ PATH=/usr/local/bin:$PATH
 cd "$TO"
 
 # Check if repo has been initialized
-echo "initalizing repo"
 if [[ ! -d "$TO"/.repo ]]; then
+    echo "initalizing repo"
     repo init -u "$UPSTREAM" --mirror
 fi
 


### PR DESCRIPTION
### Checklist

- [x] 更新 README

添加了 `google-repo`，用于同步使用 `repo` 工具构建的项目的仓库（目前只有 AOSP）。在本地测试过，看起来是可以用的（AOSP 太大了，不能跑完整同步测试）。