### PR TITLE
add support for extra settings in lftp

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,12 +309,13 @@ A new solution to sync Julia general registry (using `StorageMirrorServer.jl`). 
 [![lftpsync](https://img.shields.io/docker/image-size/ustcmirror/lftpsync/latest)](https://hub.docker.com/r/ustcmirror/lftpsync "lftpsync")
 [![lftpsync](https://img.shields.io/docker/pulls/ustcmirror/lftpsync)](https://hub.docker.com/r/ustcmirror/lftpsync "lftpsync")
 
-| Parameter          | Description                                     |
-| ------------------ | ----------------------------------------------- |
-| `LFTPSYNC_HOST`    | The hostname of the remote server.              |
-| `LFTPSYNC_PATH`    | The destination path on the remote server.      |
-| `LFTPSYNC_EXCLUDE` | Files to be excluded. Defaults to `-X .~tmp~/`. |
-| `LFTPSYNC_JOBS`    | Defaults to `$(getconf _NPROCESSORS_ONLN)`.     |
+| Parameter            | Description                                                                             |
+|----------------------|-----------------------------------------------------------------------------------------|
+| `LFTPSYNC_HOST`      | The hostname of the remote server.                                                      |
+| `LFTPSYNC_PATH`      | The destination path on the remote server.                                              |
+| `LFTPSYNC_EXCLUDE`   | Files to be excluded. Defaults to `-X .~tmp~/`.                                         |
+| `LFTPSYNC_JOBS`      | Defaults to `$(getconf _NPROCESSORS_ONLN)`.                                             |
+| `LFTPSYNC_EXTRA_SET` | Extra `set` options for lftp (ie. `set sftp:connect-program "ssh -axi <keyfile>";`) |
 
 ### nix-channels
 

--- a/README.md
+++ b/README.md
@@ -309,13 +309,14 @@ A new solution to sync Julia general registry (using `StorageMirrorServer.jl`). 
 [![lftpsync](https://img.shields.io/docker/image-size/ustcmirror/lftpsync/latest)](https://hub.docker.com/r/ustcmirror/lftpsync "lftpsync")
 [![lftpsync](https://img.shields.io/docker/pulls/ustcmirror/lftpsync)](https://hub.docker.com/r/ustcmirror/lftpsync "lftpsync")
 
-| Parameter            | Description                                                                             |
-|----------------------|-----------------------------------------------------------------------------------------|
-| `LFTPSYNC_HOST`      | The hostname of the remote server.                                                      |
-| `LFTPSYNC_PATH`      | The destination path on the remote server.                                              |
-| `LFTPSYNC_EXCLUDE`   | Files to be excluded. Defaults to `-X .~tmp~/`.                                         |
-| `LFTPSYNC_JOBS`      | Defaults to `$(getconf _NPROCESSORS_ONLN)`.                                             |
-| `LFTPSYNC_EXTRA_SET` | Extra `set` options for lftp (ie. `set sftp:connect-program "ssh -axi <keyfile>";`) |
+| Parameter                    | Description                                                                                                                |
+|------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| `LFTPSYNC_HOST`              | The hostname of the remote server.                                                                                         |
+| `LFTPSYNC_PATH`              | The destination path on the remote server.                                                                                 |
+| `LFTPSYNC_EXCLUDE`           | Files to be excluded. Defaults to `-X .~tmp~/`.                                                                            |
+| `LFTPSYNC_JOBS`              | Defaults to `$(getconf _NPROCESSORS_ONLN)`.                                                                                |
+| `LFTPSYNC_EXTRA_COMMANDS`    | Extra commands for lftp (ie. `set sftp:connect-program "ssh -axi <keyfile>";`). Will be executed before opening connection |
+| `LFTPSYNC_EXTRA_MIRROR_ARGS` | Extra parameters for mirror command (ie. -R for reverse mirror direction)                                                  |
 
 ### nix-channels
 

--- a/lftpsync/sync.sh
+++ b/lftpsync/sync.sh
@@ -12,7 +12,8 @@
 #LFTPSYNC_PATH=
 #LFTPSYNC_EXCLUDE=
 #LFTPSYNC_JOBS=
-#LFTPSYNC_EXTRA_SET=
+#LFTPSYNC_EXTRA_COMMANDS=
+#LFTPSYNC_EXTRA_MIRROR_ARGS=
 
 LFTPSYNC_MAX_JOBS=32  # count of processors on mirrors2
 
@@ -27,7 +28,8 @@ set -eu
 LFTPSYNC_PATH=${LFTPSYNC_PATH:-}
 LFTPSYNC_JOBS="${LFTPSYNC_JOBS:-$(getconf _NPROCESSORS_ONLN)}"
 LFTPSYNC_EXCLUDE="${LFTPSYNC_EXCLUDE:- -X .~tmp~/}"
-LFTPSYNC_EXTRA_SET=${LFTPSYNC_EXTRA_SET:-}
+LFTPSYNC_EXTRA_COMMANDS="${LFTPSYNC_EXTRA_COMMANDS:-}"
+LFTPSYNC_EXTRA_MIRROR_ARGS="${LFTPSYNC_EXTRA_MIRROR_ARGS:-}"
 BIND_ADDRESS="${BIND_ADDRESS:-}"
 
 if [ "$LFTPSYNC_JOBS" -gt "$LFTPSYNC_MAX_JOBS" ]; then
@@ -46,15 +48,13 @@ if [[ -n $BIND_ADDRESS ]]; then
     fi
 fi
 
-if [[ ! -z "$LFTPSYNC_EXTRA_SET" ]]; then
-  commands+=$LFTPSYNC_EXTRA_SET
-
-  [[ "${LFTPSYNC_EXTRA_SET: -1}" != ";" ]] && commands+=";"
+if [[ ! -z "$LFTPSYNC_EXTRA_COMMANDS" ]]; then
+  commands+="$LFTPSYNC_EXTRA_COMMANDS;"
 fi
 
 commands+="open $LFTPSYNC_HOST;"
 commands+="lcd $TO;"
-commands+="mirror --verbose --use-cache -aec --parallel=$LFTPSYNC_JOBS $LFTPSYNC_EXCLUDE"
+commands+="mirror --verbose --use-cache -aec $LFTPSYNC_EXTRA_MIRROR_ARGS --parallel=$LFTPSYNC_JOBS $LFTPSYNC_EXCLUDE"
 
 if [[ -n $LFTPSYNC_PATH ]]; then
     commands+=" $LFTPSYNC_PATH"

--- a/lftpsync/sync.sh
+++ b/lftpsync/sync.sh
@@ -12,6 +12,7 @@
 #LFTPSYNC_PATH=
 #LFTPSYNC_EXCLUDE=
 #LFTPSYNC_JOBS=
+#LFTPSYNC_EXTRA_SET=
 
 LFTPSYNC_MAX_JOBS=32  # count of processors on mirrors2
 
@@ -26,6 +27,7 @@ set -eu
 LFTPSYNC_PATH=${LFTPSYNC_PATH:-}
 LFTPSYNC_JOBS="${LFTPSYNC_JOBS:-$(getconf _NPROCESSORS_ONLN)}"
 LFTPSYNC_EXCLUDE="${LFTPSYNC_EXCLUDE:- -X .~tmp~/}"
+LFTPSYNC_EXTRA_SET=${LFTPSYNC_EXTRA_SET:-}
 BIND_ADDRESS="${BIND_ADDRESS:-}"
 
 if [ "$LFTPSYNC_JOBS" -gt "$LFTPSYNC_MAX_JOBS" ]; then
@@ -42,6 +44,12 @@ if [[ -n $BIND_ADDRESS ]]; then
         commands+="set net:socket-bind-ipv4 $BIND_ADDRESS;"
         commands+="set dns:order \"inet inet6\";"
     fi
+fi
+
+if [[ ! -z "$LFTPSYNC_EXTRA_SET" ]]; then
+  commands+=$LFTPSYNC_EXTRA_SET
+
+  [[ "${LFTPSYNC_EXTRA_SET: -1}" != ";" ]] && commands+=";"
 fi
 
 commands+="open $LFTPSYNC_HOST;"


### PR DESCRIPTION
In our project we need to upload logs to sftp over ssh and use custom key to login to remote SSH server. It is currently not possible to send extra `set` command to lftp, so I have created simple patch to enable it. User can easily add env variable LFTPSYNC_EXTRA_SET in docker-compose with one or more custom sets and it will be placet before mirror command.
