### PR TITLE
winget-source: add retry support for `fetch`

### DIFF
--- a/winget-source/package-lock.json
+++ b/winget-source/package-lock.json
@@ -10,8 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.4",
+        "fetch-retry": "^5.0.4",
         "jszip": "^3.10.1",
-        "node-fetch": "^3.3.0",
+        "node-fetch": "^3.3.1",
         "sqlite3": "^5.1.4",
         "winston": "^3.8.2"
       }
@@ -418,6 +419,11 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
+    },
+    "node_modules/fetch-retry": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.4.tgz",
+      "integrity": "sha512-LXcdgpdcVedccGg0AZqg+S8lX/FCdwXD92WNZ5k5qsb0irRhSFsBOpcJt7oevyqT2/C2nEE0zSFNdBEpj3YOSw=="
     },
     "node_modules/fn.name": {
       "version": "1.1.0",
@@ -915,9 +921,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",

--- a/winget-source/package.json
+++ b/winget-source/package.json
@@ -8,8 +8,9 @@
   "type": "module",
   "dependencies": {
     "async": "^3.2.4",
+    "fetch-retry": "^5.0.4",
     "jszip": "^3.10.1",
-    "node-fetch": "^3.3.0",
+    "node-fetch": "^3.3.1",
     "sqlite3": "^5.1.4",
     "winston": "^3.8.2"
   },

--- a/winget-source/utilities.js
+++ b/winget-source/utilities.js
@@ -1,6 +1,7 @@
+import withRetry from 'fetch-retry'
 import https from 'https'
 import JSZip from 'jszip'
-import fetch from 'node-fetch'
+import originalFetch from 'node-fetch'
 import os from 'os'
 import path from 'path'
 import process from 'process'
@@ -8,6 +9,13 @@ import sqlite3 from 'sqlite3'
 import winston from 'winston'
 import { existsSync } from 'fs'
 import { mkdir, mkdtemp, readFile, stat, utimes, writeFile } from 'fs/promises'
+
+/**
+ * `fetch` implementation with retry support.
+ *
+ * Defaults to 3 retries with 1000ms delay, on network errors only.
+ */
+const fetch = withRetry(originalFetch);
 
 /** The remote URL of a pre-indexed WinGet source repository. */
 const remote = process.env.WINGET_REPO_URL ?? 'https://cdn.winget.microsoft.com/cache';


### PR DESCRIPTION
为 `winget-source` 工具引入 HTTP 请求重试功能，减少网络错误导致的同步失败。