### PR TITLE
winget-source: adjust sync logic based on stronger assumption

### DIFF
--- a/winget-source/sync-repo.js
+++ b/winget-source/sync-repo.js
@@ -27,7 +27,8 @@ syncFile('source.msix').catch(exitOnError(EX_UNAVAILABLE)).then(async _ => {
         db.all('SELECT pathpart FROM manifest ORDER BY rowid DESC', (error, rows) => {
             db.close();
             const uris = buildURIList(error, rows, pathparts);
-            async.eachLimit(uris, parallelLimit, syncFile, (error) => {
+            const download = (uri) => syncFile(uri, false);
+            async.eachLimit(uris, parallelLimit, download, (error) => {
                 rm(temp, { recursive: true });
                 exitOnError(EX_TEMPFAIL)(error);
                 winston.info(`successfully synced with ${remote}`);

--- a/winget-source/utilities.js
+++ b/winget-source/utilities.js
@@ -235,14 +235,19 @@ export function setupEnvironment() {
  * Sync a file with the remote server asynchronously.
  *
  * @param {string} uri URI to sync.
+ * @param {boolean} update Whether to allow updating an existing file.
  *
  * @returns {Promise<boolean>} If the file is new or updated.
  */
-export async function syncFile(uri) {
+export async function syncFile(uri, update = true) {
     const localPath = getLocalPath(uri);
     const remoteURL = getRemoteURL(uri);
     await mkdir(path.dirname(localPath), { recursive: true });
     if (existsSync(localPath)) {
+        if (!update) {
+            winston.debug(`skipped ${uri} because it already exists`);
+            return false;
+        }
         const response = await fetch(remoteURL, { method: 'HEAD' });
         const lastModified = getLastModifiedDate(response);
         const contentLength = getContentLength(response);

--- a/winget-source/utilities.js
+++ b/winget-source/utilities.js
@@ -256,7 +256,8 @@ export async function syncFile(uri) {
     }
     winston.info(`downloading from ${remoteURL}`);
     const response = await fetch(remoteURL);
-    await writeFile(localPath, response.body);
+    const buffer = await response.arrayBuffer();
+    await writeFile(localPath, Buffer.from(buffer));
     const lastModified = getLastModifiedDate(response);
     if (lastModified) {
         await utimes(localPath, lastModified, lastModified);


### PR DESCRIPTION
我们假定所有清单文件不会被更新，因此只需要同步索引和新增的清单。