### PR TITLE
winget-source: fix bug related to `async`

### DIFF
--- a/winget-source/sync-repo.js
+++ b/winget-source/sync-repo.js
@@ -27,7 +27,7 @@ syncFile('source.msix').catch(exitOnError(EX_UNAVAILABLE)).then(async _ => {
         db.all('SELECT pathpart FROM manifest ORDER BY rowid DESC', (error, rows) => {
             db.close();
             const uris = buildURIList(error, rows, pathparts);
-            const download = (uri) => syncFile(uri, false);
+            const download = async (uri) => await syncFile(uri, false);
             async.eachLimit(uris, parallelLimit, download, (error) => {
                 rm(temp, { recursive: true });
                 exitOnError(EX_TEMPFAIL)(error);


### PR DESCRIPTION
修复了由缺失 `async` 函数标记导致的兼容性问题。