### PR TITLE
Mirgate to ghcr.io

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,14 @@ jobs:
           COMMIT_FROM: ${{ github.event.before }}
           COMMIT_TO: ${{ github.event.after }}
 
+      - name: Login to ghcr
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        if: "github.ref == 'refs/heads/master' && github.repository == 'ustclug/ustcmirror-images'"
+        with:
+            registry: "ghcr.io"
+            username: ${{ secrets.GH_USER }}
+            password: ${{ secrets.GH_TOKEN }}
+
       - name: Deploy
         if: "github.ref == 'refs/heads/master' && github.repository == 'ustclug/ustcmirror-images'"
         run: ./push.sh

--- a/apt-sync/Dockerfile
+++ b/apt-sync/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine
+FROM ghcr.io/ustcmirror/base:alpine
 MAINTAINER iBug <docker@ibugone.com>
 RUN apk add --no-cache --update wget perl ca-certificates git python3 py3-requests && \
     mkdir -p /usr/local/lib/tunasync

--- a/aptsync/Dockerfile
+++ b/aptsync/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine
+FROM ghcr.io/ustcmirror/base:alpine
 LABEL maintainer="Jian Zeng <anonymousknight96 AT gmail.com>"
 ENV APTSYNC_NTHREADS=20 \
     APTSYNC_CREATE_DIR=true \

--- a/archvsync/Dockerfile
+++ b/archvsync/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine-3.12
+FROM ghcr.io/ustcmirror/base:alpine-3.12
 LABEL maintainer="Jian Zeng <anonymousknight96 AT gmail.com>"
 ENV BASEDIR=/usr/local
 RUN apk add --no-cache rsync && mkdir -p "$BASEDIR/etc"

--- a/archvsync/build
+++ b/archvsync/build
@@ -5,4 +5,4 @@ set -e
 cd upstream
 git apply ../update.patch
 cp bin/{common,ftpsync} ..
-docker build -t ustcmirror/archvsync ..
+docker build -t ghcr.io/ustcmirror/archvsync ..

--- a/configure.py
+++ b/configure.py
@@ -229,7 +229,7 @@ def strip_prefix(s, prefix):
 
 
 def encode_tag(tag):
-    return strip_prefix(tag, 'ustcmirror/').replace(':', '.')
+    return strip_prefix(tag, 'ghcr.io/ustcmirror/').replace(':', '.')
 
 
 def get_dest_image(img, f):
@@ -237,9 +237,9 @@ def get_dest_image(img, f):
     # tag may contain a dot
     tag = strip_prefix(n, 'Dockerfile')
     if tag:
-        return 'ustcmirror/{}:{}'.format(img, tag[1:])
+        return 'ghcr.io/ustcmirror/{}:{}'.format(img, tag[1:])
     else:
-        return 'ustcmirror/{}:latest'.format(img)
+        return 'ghcr.io/ustcmirror/{}:latest'.format(img)
 
 
 def get_base_image(f):
@@ -281,7 +281,7 @@ def main():
 
     with Builder() as b:
         for dst, base in imgs.items():
-            if base.startswith('ustcmirror'):
+            if base.startswith('ghcr.io/ustcmirror'):
                 b.add(dst, base)
             else:
                 b.add(dst, '')

--- a/crates-io-index/Dockerfile
+++ b/crates-io-index/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine
+FROM ghcr.io/ustcmirror/base:alpine
 LABEL maintainer "Keyu Tao <taoky AT lug.ustc.edu.cn>"
 RUN apk add --no-cache git
 ADD sync.sh /

--- a/curl-helper/Dockerfile
+++ b/curl-helper/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine
+FROM ghcr.io/ustcmirror/base:alpine
 LABEL maintainer="Yifan Gao docker@yfgao.com"
 RUN apk add --no-cache curl coreutils grep findutils bash
 ADD curl-helper.sh /

--- a/debian-cd/Dockerfile
+++ b/debian-cd/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine-3.12
+FROM ghcr.io/ustcmirror/base:alpine-3.12
 LABEL maintainer "Jian Zeng <anonymousknight96 AT gmail.com>"
 VOLUME ["/debian"]
 ADD ["sync.sh", "pre-sync.sh", "prepare.sh", "/"]

--- a/debian-cd/prepare.sh
+++ b/debian-cd/prepare.sh
@@ -2,7 +2,7 @@
 set -e
 apk add --no-cache wget ca-certificates rsync
 mkdir -p /etc/jigdo
-wget 'http://atterer.org/sites/atterer/files/2009-08/jigdo/jigdo-bin-0.7.3.tar.bz2'
+wget 'https://ftp.lug.ustc.edu.cn/misc/jigdo-bin-0.7.3.tar.bz2'
 tar xf jigdo-bin-0.7.3.tar.bz2 jigdo-bin-0.7.3/jigdo-file
 mv jigdo-bin-0.7.3/jigdo-file /usr/local/bin/
 rm -rf jigdo-bin-*

--- a/docker-ce/Dockerfile
+++ b/docker-ce/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine
+FROM ghcr.io/ustcmirror/base:alpine
 LABEL maintainer="Keyu Tao <taoky@ustclug.org>"
 RUN apk add --no-cache --update wget perl ca-certificates git python3 py3-requests py3-pip py3-lxml && \
     pip3 install pyquery && \

--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine-3.12
+FROM ghcr.io/ustcmirror/base:alpine-3.12
 LABEL maintainer "Shengjing Zhu <zsj950618@gmail.com>"
 RUN apk add --no-cache zsh curl rsync ca-certificates gawk grep bzip2 coreutils diffutils findutils \
     && curl -fLo /usr/local/bin/quick-fedora-mirror https://pagure.io/quick-fedora-mirror/raw/master/f/quick-fedora-mirror \

--- a/freebsd-pkg/Dockerfile
+++ b/freebsd-pkg/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/curl-helper
+FROM ghcr.io/ustcmirror/curl-helper
 LABEL maintainer="Yifan Gao docker@yfgao.com"
 RUN apk add --no-cache rsync parallel gawk sed xz tar jq bash
 ADD sync.sh /

--- a/freebsd-ports/Dockerfile
+++ b/freebsd-ports/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/gitsync
+FROM ghcr.io/ustcmirror/gitsync
 LABEL maintainer="Yifan Gao <docker@yfgao.com>"
 RUN apk add --no-cache curl coreutils parallel gawk sed grep tar findutils bash
 ADD sync-ports.sh /

--- a/ghcup/Dockerfile
+++ b/ghcup/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:debian
+FROM ghcr.io/ustcmirror/base:debian
 MAINTAINER Kai Ma <ksqsf@mail.ustc.edu.cn>
 ADD ["config", "sync.sh", "prepare.sh", "ghcupsync.hs", "ghcupsync.cabal", "/"]
 RUN bash /prepare.sh && rm prepare.sh

--- a/github-release/Dockerfile
+++ b/github-release/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine
+FROM ghcr.io/ustcmirror/base:alpine
 LABEL maintainer "Yulong Ming <myl.ustc@gmail.com>"
 RUN apk add --no-cache python3 py3-requests py3-yaml && \
     mkdir -p /usr/local/lib/tunasync

--- a/gitsync/Dockerfile
+++ b/gitsync/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine
+FROM ghcr.io/ustcmirror/base:alpine
 LABEL maintainer "Jian Zeng <anonymousknight96 AT gmail.com>"
 RUN apk add --no-cache git
 ADD sync.sh /

--- a/google-repo/Dockerfile
+++ b/google-repo/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine
+FROM ghcr.io/ustcmirror/base:alpine
 LABEL maintainer "Keyu Tao <taoky AT lug.ustc.edu.cn>"
 RUN apk add --no-cache git curl python3 openssh-client gnupg && \
     curl -fLo /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \

--- a/gsutil-rsync/Dockerfile
+++ b/gsutil-rsync/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine
+FROM ghcr.io/ustcmirror/base:alpine
 LABEL maintainer "Yao Wei (魏銘廷) <mwei@lxde.org>"
 
 RUN apk add --no-cache python3 py-setuptools openssl libffi && \

--- a/hackage/Dockerfile
+++ b/hackage/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine
+FROM ghcr.io/ustcmirror/base:alpine
 MAINTAINER Jiahao Li <gloit042@gmail.com>
 ENV HACKAGE_BASE_URL=https://hackage.haskell.org
 RUN apk add --no-cache wget ca-certificates coreutils

--- a/homebrew-bottles/Dockerfile
+++ b/homebrew-bottles/Dockerfile
@@ -4,7 +4,7 @@ COPY bottles-json .
 RUN apk add --no-cache musl-dev
 RUN cargo build --release
 
-FROM ustcmirror/curl-helper
+FROM ghcr.io/ustcmirror/curl-helper
 LABEL maintainer="Yifan Gao docker@yfgao.com"
 RUN apk add --no-cache parallel bash sed gzip
 ADD sync.sh /

--- a/julia-storage/Dockerfile
+++ b/julia-storage/Dockerfile
@@ -1,5 +1,5 @@
 # Ref: https://github.com/tuna/tunasync-scripts/tree/master/dockerfiles/julia
-FROM ustcmirror/base:alpine
+FROM ghcr.io/ustcmirror/base:alpine
 
 ENV JULIA_DEPOT_PATH="/opt/julia/depot"
 RUN apk update && apk add --no-cache curl python3 gnupg py3-pip && \

--- a/lftpsync/Dockerfile
+++ b/lftpsync/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine
+FROM ghcr.io/ustcmirror/base:alpine
 LABEL maintainer "Jian Zeng <anonymousknight96 AT gmail.com>"
 RUN apk add --no-cache lftp ca-certificates
 ADD sync.sh /

--- a/misc/Dockerfile
+++ b/misc/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine
+FROM ghcr.io/ustcmirror/base:alpine
 LABEL maintainer "Keyu Tao <taoky AT ustclug.org>"
 RUN apk add --no-cache wget
 ADD sync.sh /

--- a/nix-channels/Dockerfile
+++ b/nix-channels/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine
+FROM ghcr.io/ustcmirror/base:alpine
 
 RUN \
     # Install Nix. To simplify management we only copy binaries and create

--- a/push.sh
+++ b/push.sh
@@ -2,18 +2,21 @@
 
 [[ $DEBUG = true ]] && set -x
 
-if [[ $GITHUB_EVENT_NAME != push && $GITHUB_EVENT_NAME != schedule ]]; then
-    exit 0
-fi
-if [[ $GITHUB_EVENT_NAME == push && $GITHUB_REF != "refs/heads/master" ]]; then
-    exit 0
-fi
+case $GITHUB_EVENT_NAME in
+    push|schedule|workflow_dispatch)
+        if [[ $GITHUB_REF != "refs/heads/master" ]]; then
+            exit 0
+        fi
+        ;;
+    *)
+        exit 0
+        ;;
+esac
 
 [[ -z $SKIP_LOGIN ]] && docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
 
 for image in $(docker images --filter=label=org.ustcmirror.images=true --format="{{.Repository}}:{{.Tag}}")
 do
-    docker push "$image"
-    echo "$image pushed"
+    docker push "$image" && echo "$image pushed"
 done
 

--- a/push.sh
+++ b/push.sh
@@ -17,6 +17,7 @@ esac
 
 for image in $(docker images --filter=label=org.ustcmirror.images=true --format="{{.Repository}}:{{.Tag}}")
 do
-    docker push "$image" && echo "$image pushed"
+    docker push "$image" && echo "$image pushed to ghcr.io"
+    docker tag "$image" "docker.io/${image##ghcr.io/}" && docker push "docker.io/${image##ghcr.io/}" && echo "$image pushed to docker.io"
 done
 

--- a/pypi/Dockerfile
+++ b/pypi/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine
+FROM ghcr.io/ustcmirror/base:alpine
 MAINTAINER Yifan Gao <docker@yfgao.com>
 ENV PYPI_MASTER=https://pypi.python.org \
     BANDERSNATCH_WORKERS=3 \

--- a/rclone/Dockerfile
+++ b/rclone/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine
+FROM ghcr.io/ustcmirror/base:alpine
 LABEL maintainer "Jian Zeng <anonymousknight96 AT gmail.com>"
 
 ARG RCLONE_VERSION=v1.50.2

--- a/rsync/Dockerfile
+++ b/rsync/Dockerfile
@@ -1,10 +1,10 @@
-FROM ustcmirror/base:alpine-3.12 AS builder
+FROM ghcr.io/ustcmirror/base:alpine-3.12 AS builder
 RUN apk add --no-cache build-base
 WORKDIR /tmp
 ADD lchmod.c .
 RUN gcc -Wall -fPIC -shared -o lchmod.so lchmod.c
 
-FROM ustcmirror/base:alpine-3.12
+FROM ghcr.io/ustcmirror/base:alpine-3.12
 LABEL maintainer "Jian Zeng <anonymousknight96 AT gmail.com>"
 RUN apk add --no-cache rsync openssh-client
 ADD sync.sh /

--- a/rubygems/Dockerfile
+++ b/rubygems/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine
+FROM ghcr.io/ustcmirror/base:alpine
 MAINTAINER Yifan Gao <docker@yfgao.com>
 ENV UPSTREAM=http://rubygems.org
 RUN apk add --no-cache ruby ca-certificates && \

--- a/stackage/Dockerfile
+++ b/stackage/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:debian
+FROM ghcr.io/ustcmirror/base:debian
 MAINTAINER Jiahao Li <gloit042@gmail.com>
 ADD ["config", "sync.sh", "prepare.sh", "stackage.hs", "/"]
 RUN bash /prepare.sh && rm prepare.sh

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,3 +1,3 @@
-FROM ustcmirror/base:alpine
+FROM ghcr.io/ustcmirror/base:alpine
 LABEL maintainer "Jian Zeng <anonymousknight96 AT gmail.com>"
 ADD sync.sh /

--- a/winget-source/Dockerfile
+++ b/winget-source/Dockerfile
@@ -1,4 +1,4 @@
-FROM ustcmirror/base:alpine
+FROM ghcr.io/ustcmirror/base:alpine
 LABEL maintainer "YR Chen <stevapple@icloud.com>"
 
 RUN apk add --no-cache nodejs

--- a/yum-sync/Dockerfile
+++ b/yum-sync/Dockerfile
@@ -1,9 +1,9 @@
-FROM ustcmirror/base:debian AS builder
+FROM ghcr.io/ustcmirror/base:debian AS builder
 COPY binder.c /tmp/binder.c
 RUN apt update && apt install -y build-essential && \
     gcc -Wall -fPIC -shared -o /tmp/binder.so /tmp/binder.c
 
-FROM ustcmirror/base:debian
+FROM ghcr.io/ustcmirror/base:debian
 LABEL maintainer="Keyu Tao <taoky@ustclug.org>"
 RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' > /etc/apt/sources.list.d/backports.list && \
     apt update && apt install -y dnf createrepo-c dnf-plugins-core python3 python3-requests && \


### PR DESCRIPTION
### Checklist

- [ ] 更新 README

(如果方便的话, 可以简述一下您所做的改动)

#93 

为避免 Docker Hub 清退 Free Team 账号的影响，将镜像迁移到 `ghcr.io`
镜像构建过程使用 `ghcr.io`，该版本将同时上传镜像至 `ghcr.io` 和 `docker.io`