### PR TITLE
Add yukina

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
     - [stackage](#stackage)
     - [tsumugu](#tsumugu)
     - [winget-source](#winget-source)
+    - [yukina](#yukina)
     - [yum-sync](#yum-sync)
   - [License](#license)
   - [Contributing](#contributing)
@@ -419,7 +420,7 @@ Stackage doesn't need to specify upstream.
 ### tsumugu
 
 [![tsumugu](https://img.shields.io/docker/image-size/ustcmirror/tsumugu/latest)](https://hub.docker.com/r/ustcmirror/tsumugu "tsumugu")
-[![stackage](https://img.shields.io/docker/pulls/ustcmirror/tsumugu)](https://hub.docker.com/r/ustcmirror/tsumugu "tsumugu")
+[![tsumugu](https://img.shields.io/docker/pulls/ustcmirror/tsumugu)](https://hub.docker.com/r/ustcmirror/tsumugu "tsumugu")
 
 An alternative HTTP(S) syncing tool, replacing `rclone` and `lftp` in some cases. See [usage](https://github.com/taoky/tsumugu#usage).
 
@@ -445,6 +446,22 @@ A handy tool to sync pre-indexed [Windows Package Manager](https://github.com/mi
 | --------------------- | ---------------------------------------------------------------- |
 | `WINGET_REPO_URL`     | Sets the URL of upstream. Defaults to [`https://cdn.winget.microsoft.com/cache`](https://cdn.winget.microsoft.com/cache) |
 | `WINGET_REPO_JOBS`    | Parallel jobs. Defaults to 8.                                    |
+
+### yukina
+
+[![yukina](https://img.shields.io/docker/image-size/ustcmirror/yukina/latest)](https://hub.docker.com/r/ustcmirror/yukina "yukina")
+[![yukina](https://img.shields.io/docker/pulls/ustcmirror/yukina)](https://hub.docker.com/r/ustcmirror/yukina "yukina")
+
+[yukina](https://github.com/taoky/yukina) analyses given nginx log, and maintains binary blobs (which does not modify once exist) state under given size limit.
+Usually this shall be used with another sync container that only downloads index files.
+
+Note that you shall bind necessary nginx log to `/nginx-log/` when syncing.
+
+| Parameter          | Description                                                                                           |
+| ------------------ | ----------------------------------------------------------------------------------------------------- |
+| `YUKINA_SIZE_LIMIT` | The size limit of binary blobs. Defaults to `512g`.                                                     |
+| `YUKINA_FILTER` | Accepts regex to filter out binary blobs. Defaults to empty. |
+| `YUKINA_EXTRA`  | Extra options. Defaults to empty.                                                                      |
 
 ### yum-sync
 

--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ Note that you shall bind necessary nginx log to `/nginx-log/` when syncing.
 
 | Parameter          | Description                                                                                           |
 | ------------------ | ----------------------------------------------------------------------------------------------------- |
+| `UPSTREAM`        | Sets the url of upstream.                                                                             |
 | `YUKINA_SIZE_LIMIT` | The size limit of binary blobs. Defaults to `512g`.                                                     |
 | `YUKINA_FILTER` | Accepts regex to filter out binary blobs. Defaults to empty. |
 | `YUKINA_EXTRA`  | Extra options. Defaults to empty.                                                                      |

--- a/yukina/Dockerfile
+++ b/yukina/Dockerfile
@@ -1,0 +1,11 @@
+FROM ustcmirror/base:alpine
+LABEL maintainer "Keyu Tao <taoky AT ustclug.org>"
+ARG YUKINA_VERSION=20240331
+
+RUN apk add --no-cache wget ca-certificates zstd && \
+    cd /tmp/ && wget -q "https://github.com/taoky/yukina/releases/download/${YUKINA_VERSION}/yukina" && \
+    mv /tmp/yukina /usr/local/bin/ && \
+    chmod +x /usr/local/bin/yukina && \
+    rm -rf /tmp/* && apk del wget
+
+ADD sync.sh /

--- a/yukina/Dockerfile
+++ b/yukina/Dockerfile
@@ -1,6 +1,6 @@
 FROM ustcmirror/base:alpine
 LABEL maintainer "Keyu Tao <taoky AT ustclug.org>"
-ARG YUKINA_VERSION=20240331
+ARG YUKINA_VERSION=20240331-2
 
 RUN apk add --no-cache wget ca-certificates zstd && \
     cd /tmp/ && wget -q "https://github.com/taoky/yukina/releases/download/${YUKINA_VERSION}/yukina" && \

--- a/yukina/sync.sh
+++ b/yukina/sync.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+## EXPORTED IN entry.sh
+#TO=
+#REPO=
+
+## SET IN ENVIRONMENT VARIABLES
+#BIND_ADDRESS=
+#YUKINA_SIZE_LIMIT=
+#YUKINA_FILTER=
+#YUKINA_EXTRA=
+
+set -eu
+[[ $DEBUG = true ]] && set -x
+
+BIND_ADDRESS=${BIND_ADDRESS:-}
+YUKINA_SIZE_LIMIT=${YUKINA_SIZE_LIMIT:-"512g"}
+YUKINA_FILTER=${YUKINA_FILTER:-}
+YUKINA_EXTRA=${YUKINA_EXTRA:-}
+
+if [[ $DEBUG = true ]]; then
+    export RUST_LOG="yukina=debug"
+fi
+
+export NO_COLOR=1
+
+exec yukina --name "$REPO" \
+    --log-path "/nginx-log" \
+    --repo-path "$TO" \
+    --size-limit "$YUKINA_SIZE_LIMIT" \
+    --url "$UPSTREAM" \
+    --size-database "$TO/.yukina-size.db" \
+    $YUKINA_FILTER $YUKINA_EXTRA

--- a/yukina/sync.sh
+++ b/yukina/sync.sh
@@ -6,6 +6,7 @@
 
 ## SET IN ENVIRONMENT VARIABLES
 #BIND_ADDRESS=
+#UPSTREAM=
 #YUKINA_SIZE_LIMIT=
 #YUKINA_FILTER=
 #YUKINA_EXTRA=
@@ -29,5 +30,6 @@ exec yukina --name "$REPO" \
     --repo-path "$TO" \
     --size-limit "$YUKINA_SIZE_LIMIT" \
     --url "$UPSTREAM" \
-    --size-database "$TO/.yukina-size.db" \
+    --remote-sizedb "$TO/.yukina-remote.db" \
+    --local-sizedb "$TO/.yukina-local.db" \
     $YUKINA_FILTER $YUKINA_EXTRA


### PR DESCRIPTION
### Checklist

- [x] 更新 README

(如果方便的话, 可以简述一下您所做的改动)

<https://github.com/taoky/yukina>

作为解决 nix-channels 占用空间巨大（而且还不完整），但是实际使用的内容很少的方案。Yukina 会分析对应时长（现在是 7 天）的 nginx 日志，在给定的大小约束下下载流行的文件，驱逐（删除）不流行的文件。

预期的使用方式是：原先的同步容器仍然运行，但是只同步 index；Nginx 设置对不存在的文件 302 或者 404，并且日志以特定名称输出到特定的目录下。Yukina 运行时（理想情况下，需要相对较高的执行频率）从挂载的日志中读取内容、只对 binary blob 类型的文件（大多数时候需要用户自己写正则 filter 规则）进行操作。

