### PR TITLE
winget-source: migrate from `Promise` to `async/await`

### DIFF
--- a/winget-source/package-lock.json
+++ b/winget-source/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "@ustcmirror/winget-source",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ustcmirror/winget-source",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.4",
         "fetch-retry": "^5.0.4",
         "jszip": "^3.10.1",
         "node-fetch": "^3.3.1",
+        "promised-sqlite3": "^2.1.0",
         "sqlite3": "^5.1.5",
         "winston": "^3.8.2"
       }
@@ -1231,6 +1232,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/promised-sqlite3": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/promised-sqlite3/-/promised-sqlite3-2.1.0.tgz",
+      "integrity": "sha512-g227r1cE/GrP7UfQdiwi1URAc7HL2LAulNrDC0vYMWcI387Urc5VoIinoXfXWDi546sZUM7gQhxrNr9a9nXN1Q==",
+      "peerDependencies": {
+        "sqlite3": "^5"
       }
     },
     "node_modules/pump": {

--- a/winget-source/package.json
+++ b/winget-source/package.json
@@ -11,6 +11,7 @@
     "fetch-retry": "^5.0.4",
     "jszip": "^3.10.1",
     "node-fetch": "^3.3.1",
+    "promised-sqlite3": "^2.1.0",
     "sqlite3": "^5.1.5",
     "winston": "^3.8.2"
   },

--- a/winget-source/sync-repo.js
+++ b/winget-source/sync-repo.js
@@ -2,12 +2,13 @@ import assert from 'assert'
 import async from 'async'
 
 import { rm } from 'fs/promises'
-import { EX_IOERR, EX_TEMPFAIL, EX_UNAVAILABLE } from './sysexits.js'
+import { AsyncDatabase } from 'promised-sqlite3'
+import { EX_IOERR, EX_OK, EX_SOFTWARE, EX_TEMPFAIL, EX_UNAVAILABLE } from './sysexits.js'
 
 import {
     buildPathpartMap,
     buildURIList,
-    exitOnError,
+    exitWithCode,
     extractDatabaseFromBundle,
     getLocalPath,
     makeTempDirectory,
@@ -17,38 +18,56 @@ import {
 } from './utilities.js'
 
 
-const { parallelLimit, remote, sqlite3, winston } = setupEnvironment();
-
-winston.info(`start syncing with ${remote}`);
-
 const sourceV1Filename = 'source.msix';
 const sourceV2Filename = 'source2.msix';
 
-syncFile(sourceV1Filename, true, false).catch(exitOnError(EX_UNAVAILABLE)).then(async result => {
-    assert(result, "Failed to catch error when syncing source index!");
-    const [indexBuffer, modifiedDate, synced] = result;
-    if (synced) {
-        assert(indexBuffer !== null, "Failed to get the source index buffer!");
-        const temp = await makeTempDirectory('winget-repo-');
-        const database = await extractDatabaseFromBundle(indexBuffer, temp);
-        const db = new sqlite3.Database(database, sqlite3.OPEN_READONLY, exitOnError(EX_IOERR));
+// set up configs and temp directory
+const { parallelLimit, remote, sqlite3, winston } = setupEnvironment();
+const tempDirectory = await makeTempDirectory('winget-repo-');
 
-        db.all('SELECT * FROM pathparts', (error, rows) => {
-            const pathparts = buildPathpartMap(error, rows);
-            db.all('SELECT pathpart FROM manifest ORDER BY rowid DESC', (error, rows) => {
-                db.close();
-                const uris = buildURIList(error, rows, pathparts);
-                const download = async (uri) => await syncFile(uri, false);
-                async.eachLimit(uris, parallelLimit, download, (error) => {
-                    rm(temp, { recursive: true });
-                    exitOnError(EX_TEMPFAIL)(error);
-                    saveFile(getLocalPath(sourceV1Filename), indexBuffer, modifiedDate).then(_ =>
-                        syncFile(sourceV2Filename, true)
-                    ).then(_ => {
-                        winston.info(`successfully synced with ${remote}`);
-                    });
-                });
-            });
-        });
+winston.info(`start syncing with ${remote}`);
+
+try {
+    // download V1 index package to buffer
+    const [indexBuffer, modifiedDate, updated] = await syncFile(sourceV1Filename, true, false);
+    if (!updated) {
+        exitWithCode(EX_OK);
     }
-});
+    assert(indexBuffer !== null, "Failed to get the source index buffer!");
+
+    // unpack, extract and load index database
+    try {
+        const databaseFilePath = await extractDatabaseFromBundle(indexBuffer, tempDirectory);
+        const rawDatabase = new sqlite3.Database(databaseFilePath, sqlite3.OPEN_READONLY);
+
+        // read manifest URIs from index database
+        try {
+            const db = new AsyncDatabase(rawDatabase)
+            const pathparts = buildPathpartMap(await db.all('SELECT * FROM pathparts'));
+            const uris = buildURIList(await db.all('SELECT pathpart FROM manifest ORDER BY rowid DESC'), pathparts);
+            await db.close()
+
+            // sync latest manifests in parallel
+            try {
+                await async.eachLimit(uris, parallelLimit, async (uri) => await syncFile(uri, false));
+            } catch (error) {
+                exitWithCode(EX_TEMPFAIL, error);
+            }
+        } catch (error) {
+            exitWithCode(EX_SOFTWARE, error);
+        }
+    } catch (error) {
+        exitWithCode(EX_IOERR, error);
+    }
+
+    // update index packages
+    await saveFile(getLocalPath(sourceV1Filename), indexBuffer, modifiedDate);
+    await syncFile(sourceV2Filename, true);
+} catch (error) {
+    exitWithCode(EX_UNAVAILABLE, error);
+}
+
+winston.info(`successfully synced with ${remote}`);
+
+// clean up temp directory
+await rm(tempDirectory, { recursive: true });

--- a/winget-source/sync-repo.js
+++ b/winget-source/sync-repo.js
@@ -31,6 +31,7 @@ try {
     // download V1 index package to buffer
     const [indexBuffer, modifiedDate, updated] = await syncFile(sourceV1Filename, true, false);
     if (!updated) {
+        winston.info(`nothing to sync from ${remote}`);
         exitWithCode(EX_OK);
     }
     assert(indexBuffer !== null, "Failed to get the source index buffer!");


### PR DESCRIPTION
完全使用 `async/await` 语法重写 `winget-source` 工具，增加 `sync-repo.js` 的可读性。