### PR TITLE
ghcup: support vanilla and cross compilers

### DIFF
--- a/ghcup/ghcupsync.hs
+++ b/ghcup/ghcupsync.hs
@@ -72,8 +72,21 @@ parseVersionFromFileName :: FilePath -> Maybe Version
 parseVersionFromFileName filename = do
   let basename = takeBaseName filename
   noPrefix <- stripPrefix "ghcup-prereleases-" basename
+          <|> stripPrefix "ghcup-cross-" basename
+          <|> stripPrefix "ghcup-vanilla-" basename
           <|> stripPrefix "ghcup-" basename
   listToMaybe $ map fst . filter (\(_, rem) -> null rem) $ readP_to_S parseVersion noPrefix
+
+-- This versoin of parseVersionFromFileName may have more forward compatability
+-- but poorer performance
+-- parseVersionFromFileName filename = do
+--   let basename = takeBaseName filename
+--   case find isJust . map tryParse $ tails basename of
+--     (Just m) -> m -- if found, it will be a double Just, i.e. (Just (Just Version))
+--     Nothing  -> Nothing
+--   where
+--     tryParse :: String -> Maybe Version
+--     tryParse = listToMaybe . map fst . reverse . readP_to_S parseVersion
 
 ------------------------------------------------------------------------
 syncByMetadata :: FilePath -> FilePath -> IO ()

--- a/ghcup/ghcupsync.hs
+++ b/ghcup/ghcupsync.hs
@@ -77,7 +77,7 @@ parseVersionFromFileName filename = do
           <|> stripPrefix "ghcup-" basename
   listToMaybe $ map fst . filter (\(_, rem) -> null rem) $ readP_to_S parseVersion noPrefix
 
--- This versoin of parseVersionFromFileName may have more forward compatability
+-- This version of parseVersionFromFileName may have more forward compatability
 -- but poorer performance
 -- parseVersionFromFileName filename = do
 --   let basename = takeBaseName filename


### PR DESCRIPTION
### Checklist

- [ ] 更新 README

ghcup metadata 在 0.0.7 添加了 vanilla ，
并在 0.0.8 添加了 cross compiler ，
而在原本的 version parser 中并没有支持。

我修改了 parseVersionFromFileName 以添加支持，
同时考虑到未来可能的更多不同 metadata 版本，
实现了向前兼容（但性能更差的） parser 版本。