### PR TITLE
freebsd-pkg: Add Kmod

### DIFF
--- a/freebsd-pkg/sync.sh
+++ b/freebsd-pkg/sync.sh
@@ -86,7 +86,7 @@ fi
 
 while read platform; do
 	echo "[INFO] getting channel list of $platform..."
-	channels=$($CURL_WRAP -sSL $FBSD_PKG_UPSTREAM/$platform | grep -oP 'latest|quarterly|base_[a-z0-9_]+|kmods_[a-z0-9_]+|release_[a-z0-9_]+' | sort -t : -rnk 2 | uniq)
+	channels=$($CURL_WRAP -sSL $FBSD_PKG_UPSTREAM/$platform | grep -oP 'latest|quarterly|base_[a-z0-9_]+|kmods_[a-z0-9_]+' | sort -t : -rnk 2 | uniq)
  	echo $channels
 	for channel in $channels; do
 		if $CURL_WRAP -sLIf -o /dev/null $FBSD_PKG_UPSTREAM/$platform/$channel/packagesite.txz; then

--- a/freebsd-pkg/sync.sh
+++ b/freebsd-pkg/sync.sh
@@ -86,7 +86,7 @@ fi
 
 while read platform; do
 	echo "[INFO] getting channel list of $platform..."
-	channels=$($CURL_WRAP -sSL $FBSD_PKG_UPSTREAM/$platform | grep -oP 'latest|quarterly|base_[a-z0-9_]+' | sort -t : -rnk 2 | uniq)
+	channels=$($CURL_WRAP -sSL $FBSD_PKG_UPSTREAM/$platform | grep -oP 'latest|quarterly|base_[a-z0-9_]+|kmods_[a-z0-9_]+|release_[a-z0-9_]+' | sort -t : -rnk 2 | uniq)
  	echo $channels
 	for channel in $channels; do
 		if $CURL_WRAP -sLIf -o /dev/null $FBSD_PKG_UPSTREAM/$platform/$channel/packagesite.txz; then


### PR DESCRIPTION
增加 FreeBSD 模块源、补充 pkgbase 源。

现在的 base* 源是 stable 分支 pkgbase 更新用的，而 release* 是 release 分支  pkgbase 更新用的。

模块源参见 

- <https://lists.freebsd.org/archives/freebsd-ports/2024-December/006997.html>
- <https://forums.freebsd.org/threads/possible-solution-to-the-drm-kmod-kernel-mismatch-after-upgrade-from-bapt.96058/>
