### PR TITLE
Erchiusx ghcup bootstrap cabal

### DIFF
--- a/ghcup/ghcupsync.hs
+++ b/ghcup/ghcupsync.hs
@@ -83,7 +83,9 @@ main = do
     sameChannel m1 m2 = channel m1 == channel m2
 
     link :: (FilePath, FilePath) -> IO ()
-    link link'target = createSymbolicLink (snd link'target) (fst link'target)
+    link link'target = do
+      createSymbolicLink (snd link'target) (fst link'target)
+      createSymbolicLink (snd link'target ++ ".sig") (fst link'target ++ ".sig")
 
 ghcupMetadataRepo :: URL
 ghcupMetadataRepo = "https://github.com/haskell/ghcup-metadata"

--- a/ghcup/sync.sh
+++ b/ghcup/sync.sh
@@ -9,6 +9,8 @@ mkdir -p "$TO/sh"
 pushd "$TO/sh"
 curl https://raw.githubusercontent.com/haskell/ghcup-hs/master/scripts/bootstrap/bootstrap-haskell -o bootstrap-haskell
 sed -i 's|https://downloads.haskell.org/~ghcup|https://mirrors.ustc.edu.cn/ghcup/downloads.haskell.org/~ghcup|' bootstrap-haskell
+sed -i '/edo cabal update/ i \ \ \ \ edo cabal user-config update -a "repository mirrors.ustc.edu.cn" -a "  url: https://mirrors.ustc.edu.cn/hackage/" ' bootstrap-haskell
+# make ghcup init cabal config before cabal update
 curl https://raw.githubusercontent.com/haskell/ghcup-hs/master/scripts/bootstrap/bootstrap-haskell.ps1 -o bootstrap-haskell.ps1
 sed -i 's|https://www.haskell.org/ghcup/sh/bootstrap-haskell|https://mirrors.ustc.edu.cn/ghcup/sh/bootstrap-haskell|' bootstrap-haskell.ps1
 sed -i 's|https://repo.msys2.org/distrib/|https://mirrors.ustc.edu.cn/msys2/distrib/|' bootstrap-haskell.ps1

--- a/hackage/sync.sh
+++ b/hackage/sync.sh
@@ -21,7 +21,10 @@ function pull_hackage () {
     # snapshot.json contains hashes of 01-index.tar.gz
     # Download it first to minimize the chance of race condition
     echo "Download snapshot (hashes) ..."
-    $CURL_WRAP -sSL -o snapshot.json.bak "$HACKAGE_BASE_URL/snapshot.json" &> /dev/null
+    snapshot_json=("snapshot.json" "timestamp.json")
+    for json in "${snapshot_json[@]}"; do
+        $CURL_WRAP -sSL -o "$json.bak" "$HACKAGE_BASE_URL/$json" &> /dev/null
+    done
 
     echo "Download latest index ..."
     $CURL_WRAP -sSL -o index.tar.gz "$HACKAGE_BASE_URL/01-index.tar.gz" &> /dev/null
@@ -30,7 +33,7 @@ function pull_hackage () {
     $CURL_WRAP -sSL -o index-00.tar.gz "$HACKAGE_BASE_URL/00-index.tar.gz" &> /dev/null
 
     # download extra json files
-    extra_json=("mirrors.json" "root.json" "timestamp.json")
+    extra_json=("mirrors.json" "root.json")
     for json in "${extra_json[@]}"; do
         $CURL_WRAP -sSL -o "$json" "$HACKAGE_BASE_URL/$json" &> /dev/null
     done
@@ -85,6 +88,7 @@ function pull_hackage () {
     cp index.tar.gz 01-index.tar.gz
     mv index-00.tar.gz 00-index.tar.gz
     mv snapshot.json.bak snapshot.json
+    mv timestamp.json.bak timestamp.json
 }
 
 function download_pkg () {


### PR DESCRIPTION
### Checklist

- [ ] 更新 README

During the installation of cabal,
GHCup would update cabal as soon as it's installed;
But at that point, Cabal config is not adjusted to ustcmirror.
We add a logic to addjust cabal config before cabal updating.

我的疑虑是，
这样的对脚本进行的`插入一行命令`式的更新
是否会对可维护性造成破坏
