### PR TITLE
base: Bump alpine to 3.23

### DIFF
--- a/base/Dockerfile.alpine
+++ b/base/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.23
 LABEL maintainer="Jian Zeng <anonymousknight96 AT gmail.com>" \
       org.ustcmirror.images=true
 RUN <<EOF


### PR DESCRIPTION
更新 Alpine 到最新版本（3.20 已经 EOL，且 git 版本不支持计划测试提升性能的 pseudo-merge bitmap）