### PR TITLE
pytorch: rewrite absolute upstream URLs in index pages

### DIFF
--- a/pytorch/sync.py
+++ b/pytorch/sync.py
@@ -132,7 +132,13 @@ async def recursive_download(client: httpx.AsyncClient, url: str):
         if tasks:
             await asyncio.gather(*tasks)
         if not dry_run:
+            # Rewrite links so the index page points back to this mirror.
+            # Upstream now emits absolute URLs like
+            # "https://download-r2.pytorch.org/whl/..." instead of "/whl/...",
+            # so we have to handle both forms (relative + each absolute origin).
             index_resp = index_resp.replace('href="/', f'href="{urlbase}')
+            index_resp = index_resp.replace('href="https://download.pytorch.org/', f'href="{urlbase}')
+            index_resp = index_resp.replace('href="https://download-r2.pytorch.org/', f'href="{urlbase}')
             os.makedirs(base / path, exist_ok=True)
             with overwrite(base / path / filename, "w") as f:
                 f.write(index_resp)


### PR DESCRIPTION
## Problem

Upstream PyTorch index pages now emit absolute URLs of the form

```
href="https://download-r2.pytorch.org/whl/torch-2.12.0+xpu-cp311-cp311-win_amd64.whl#sha256=..."
```

(and still occasionally `https://download.pytorch.org/...`) instead of the previous relative `/whl/...` form.

`pytorch/sync.py` only rewrites `href="/`, so mirrored index pages keep the absolute URLs unchanged. Clients (`pip install -i https://<mirror>/pytorch/whl/xpu`) parse those links and get redirected back to the upstream origin (Cloudflare R2 in this case) instead of pulling from the mirror.

The actual `.whl` files are still synced correctly by `recursive_download`, so manually constructing a mirror URL works:

```
pip install https://<mirror>/pytorch/whl/xpu/torch-2.12.0+xpu-cp311-cp311-win_amd64.whl  # works
pip install torch -i https://<mirror>/pytorch/whl/xpu                                     # falls back to upstream
```

Reproduced on NJU mirror and reported in <https://github.com/nju-lug/NJU-Mirror-Issue/issues/109>.

## Fix

Add two more `replace()` calls so both absolute origins are also rewritten to the local `URLBASE`:

```python
index_resp = index_resp.replace('href="/', f'href="{urlbase}')
index_resp = index_resp.replace('href="https://download.pytorch.org/', f'href="{urlbase}')
index_resp = index_resp.replace('href="https://download-r2.pytorch.org/', f'href="{urlbase}')
```

The existing relative-path rewrite is kept for backward compatibility in case upstream switches forms again.

## Verification

- Rebuilt the image, ran one full sync, and confirmed regenerated index pages now contain `href="/pytorch/whl/..."` exclusively.
- `pip install torch -i https://<mirror>/pytorch/whl/xpu` now downloads from the mirror.