### PR TITLE
Fix crates.io file permission error

### DIFF
--- a/crates-io/sync-crates.py
+++ b/crates-io/sync-crates.py
@@ -153,6 +153,13 @@ def parse_entries_from_git(index_dir: Path, commit: str, index_files):
                 raise RuntimeError(
                     f"invalid git cat-file header for {commit}:{rel}: {header!r}"
                 ) from exc
+            if object_type == b"tree":
+                size = int(object_size)
+                process.stdout.read(size)
+                if process.stdout.read(1) != b"\n":
+                    pass
+                tqdm.write(f"[WARN] skipping tree object: {commit}:{rel}")
+                continue
             if object_type != b"blob":
                 raise RuntimeError(
                     f"unexpected git object type for {commit}:{rel}: {object_type.decode()}"
@@ -223,6 +230,7 @@ def fetch_one(
         return "downloaded"
 
     target.parent.mkdir(parents=True, exist_ok=True)
+    target.parent.chmod(0o755)
     fd, tmp_name = tempfile.mkstemp(
         prefix=target.name + ".", suffix=".tmp", dir=target.parent
     )
@@ -241,6 +249,7 @@ def fetch_one(
             # if not verify_sha256(tmp_path, checksum):
             #     raise RuntimeError(f"checksum mismatch for {name} {version}")
             os.replace(tmp_path, target)
+            target.chmod(0o644)
             return "downloaded"
         except (urllib.error.URLError, OSError, RuntimeError) as exc:
             last_error = exc

--- a/crates-io/sync-crates.py
+++ b/crates-io/sync-crates.py
@@ -3,7 +3,6 @@
 import argparse
 import io
 import os
-import uuid
 from pathlib import Path
 import shutil
 import subprocess
@@ -154,13 +153,6 @@ def parse_entries_from_git(index_dir: Path, commit: str, index_files):
                 raise RuntimeError(
                     f"invalid git cat-file header for {commit}:{rel}: {header!r}"
                 ) from exc
-            if object_type == b"tree":
-                size = int(object_size)
-                process.stdout.read(size)
-                if process.stdout.read(1) != b"\n":
-                    pass
-                tqdm.write(f"[WARN] skipping tree object: {commit}:{rel}")
-                continue
             if object_type != b"blob":
                 raise RuntimeError(
                     f"unexpected git object type for {commit}:{rel}: {object_type.decode()}"
@@ -231,7 +223,7 @@ def fetch_one(
         return "downloaded"
 
     target.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = target.parent / f"{target.name}.{uuid.uuid4().hex}.tmp"
+    tmp_path = target.parent / f"{target.name}.tmp"
 
     last_error = None
     for attempt in range(retries + 1):
@@ -250,12 +242,7 @@ def fetch_one(
             last_error = exc
             if attempt == retries:
                 break
-            if tmp_path.exists():
-                tmp_path.unlink()
-            tmp_path = target.parent / f"{target.name}.{uuid.uuid4().hex}.tmp"
 
-    if tmp_path.exists():
-        tmp_path.unlink()
     raise RuntimeError(f"failed to fetch {name} {version} from {url}: {last_error}")
 
 

--- a/crates-io/sync-crates.py
+++ b/crates-io/sync-crates.py
@@ -3,6 +3,7 @@
 import argparse
 import io
 import os
+import uuid
 from pathlib import Path
 import shutil
 import subprocess
@@ -153,6 +154,13 @@ def parse_entries_from_git(index_dir: Path, commit: str, index_files):
                 raise RuntimeError(
                     f"invalid git cat-file header for {commit}:{rel}: {header!r}"
                 ) from exc
+            if object_type == b"tree":
+                size = int(object_size)
+                process.stdout.read(size)
+                if process.stdout.read(1) != b"\n":
+                    pass
+                tqdm.write(f"[WARN] skipping tree object: {commit}:{rel}")
+                continue
             if object_type != b"blob":
                 raise RuntimeError(
                     f"unexpected git object type for {commit}:{rel}: {object_type.decode()}"
@@ -223,11 +231,7 @@ def fetch_one(
         return "downloaded"
 
     target.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_name = tempfile.mkstemp(
-        prefix=target.name + ".", suffix=".tmp", dir=target.parent
-    )
-    os.close(fd)
-    tmp_path = Path(tmp_name)
+    tmp_path = target.parent / f"{target.name}.{uuid.uuid4().hex}.tmp"
 
     last_error = None
     for attempt in range(retries + 1):
@@ -248,11 +252,7 @@ def fetch_one(
                 break
             if tmp_path.exists():
                 tmp_path.unlink()
-            fd, tmp_name = tempfile.mkstemp(
-                prefix=target.name + ".", suffix=".tmp", dir=target.parent
-            )
-            os.close(fd)
-            tmp_path = Path(tmp_name)
+            tmp_path = target.parent / f"{target.name}.{uuid.uuid4().hex}.tmp"
 
     if tmp_path.exists():
         tmp_path.unlink()

--- a/crates-io/sync-crates.py
+++ b/crates-io/sync-crates.py
@@ -153,13 +153,6 @@ def parse_entries_from_git(index_dir: Path, commit: str, index_files):
                 raise RuntimeError(
                     f"invalid git cat-file header for {commit}:{rel}: {header!r}"
                 ) from exc
-            if object_type == b"tree":
-                size = int(object_size)
-                process.stdout.read(size)
-                if process.stdout.read(1) != b"\n":
-                    pass
-                tqdm.write(f"[WARN] skipping tree object: {commit}:{rel}")
-                continue
             if object_type != b"blob":
                 raise RuntimeError(
                     f"unexpected git object type for {commit}:{rel}: {object_type.decode()}"
@@ -230,7 +223,6 @@ def fetch_one(
         return "downloaded"
 
     target.parent.mkdir(parents=True, exist_ok=True)
-    target.parent.chmod(0o755)
     fd, tmp_name = tempfile.mkstemp(
         prefix=target.name + ".", suffix=".tmp", dir=target.parent
     )
@@ -249,7 +241,6 @@ def fetch_one(
             # if not verify_sha256(tmp_path, checksum):
             #     raise RuntimeError(f"checksum mismatch for {name} {version}")
             os.replace(tmp_path, target)
-            target.chmod(0o644)
             return "downloaded"
         except (urllib.error.URLError, OSError, RuntimeError) as exc:
             last_error = exc


### PR DESCRIPTION
### Checklist

更新crates.io同步脚本，修改同步的文件夹权限为755，文件权限为644，同时增加对commit的判断，对于tree的git记录输出警告并跳过